### PR TITLE
add __typename to Node interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -269,7 +269,7 @@ export interface Node {
   id: string;
 
   /**
-   * GraphQL name of 
+   * GraphQL name of entity
    */
   __typename: PossibleNodeTypeNames;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,6 +267,11 @@ export interface Node {
    * Globally unique identifier.
    */
   id: string;
+
+  /**
+   * GraphQL name of 
+   */
+  __typename: PossibleNodeTypeNames;
 }
 
 /** Use this to resolve interface type Node */


### PR DESCRIPTION
Hello, I think each node should contain `__typename` as well, for identifying what Node type it is.